### PR TITLE
Don’t automatically swallow errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var _ = require('underscore');
-var plumber = require('gulp-plumber');
 var rollup = require('rollup-stream');
 var runSequence = require('run-sequence');
 var buffer = require('vinyl-source-buffer');
@@ -111,7 +110,6 @@ class MultiBuild {
                   this._cache.modules[module.id] = module;
                 });
               })
-              .pipe(plumber())
               .pipe(buffer(`${target}.js`))
           );
       });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/mixmaxhq/multibuild#readme",
   "dependencies": {
-    "gulp-plumber": "^1.1.0",
     "rollup-stream": "^1.14.0",
     "run-sequence": "^1.2.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
This should be left to the client to configure. We might reintroduce it into
multibuild in the future if it needs to be handled upstream of the client,
but controlled by some parameter.