### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ var build = new MultiBuild({
     'spec'
   ],
 
+  /**
+   * Optional handler for rollup-emitted errors. We allow the passing of an error handler instead of
+   * conditionally applying `gulp-plumber` because `gulp-plumber` is incompatible with
+   * `rollup-stream` per https://github.com/Permutatrix/rollup-stream/issues/1.
+   */
+  errorHandler(e) {
+    if (process.env.NODE_ENV !== 'production') {
+      // Keep watching for changes on failure.
+      console.error(e);
+    } else {
+      // Throw so that gulp exits.
+      throw(e);
+    }
+  },
+
   // A function that returns the Rollup entry point when invoked with a target.
   entry: (target) => (target === 'spec') ? 'spec/**/*.js' : `src/js/main-${target}.js`,
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,16 @@ class MultiBuild {
    */
   changed(path) {
     var changedTargetTasks = _.filter(this._targets, (target) => {
+      /**
+       * Tasks that have not yet run successfully will not be registered in `_targetDependencyMap`,
+       * which means that we won't know their dependencies. We always run these tasks on a file
+       * change until they succeed once and we get their dependencies, otherwise they will never be
+       * run after their first failure.
+       */
+      if (!_.has(this._targetDependencyMap, target)) {
+        return true;
+      }
+
       var dependencies = this._targetDependencyMap[target];
       return dependencies && dependencies.has(path);
     }).map(MultiBuild.task);


### PR DESCRIPTION
These changes:
1. Allow multibuild users to specify a handler for `rollup`-emitted errors (useful for swallowing errors during development for example).
2. Make it so that tasks that fail on their first run will continue to run on further file changes. Without this change, tasks that fail on their first run will never be re-run until `gulp watch` is re-run.