### PR TITLE
Pin rollup-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/mixmaxhq/multibuild#readme",
   "dependencies": {
-    "rollup-stream": "^1.23.1",
+    "rollup-stream": "1.23.1",
     "run-sequence": "^1.2.2",
     "underscore": "^1.8.3",
     "vinyl-source-buffer": "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,7 +258,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-rollup-stream@^1.23.1:
+rollup-stream@1.23.1:
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/rollup-stream/-/rollup-stream-1.23.1.tgz#084b489cc4f8d780a27c187a53cef6598171f102"
   dependencies:


### PR DESCRIPTION
1.24.0 was actually a breaking change insofar as it picked up a breaking version
of Rollup, which has broken
https://github.com/rollup/rollup-plugin-multi-entry/issues/24.