### PR TITLE
Add method to run groups sequentially

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,18 @@ class MultiBuild {
   }
 
   /**
+   * Builds all target bundles and registers dependencies on the files that comprise each bundle.
+   *
+   * @param {Function} done - Callback.
+   */
+  runAllSequential(done) {
+    // We support running the groups sequentially, in case the build fares better with less
+    // cross-group contention, but run each target task within a group sequentially, so that each
+    // run can benefit from the cached AST from the previous runs.
+    runSequence.use(this._gulp)(...this.taskGroups(), done);
+  }
+
+  /**
    * Rebuilds bundles dependent on the specified file, if any, as determined by a previous build
    * e.g. an invocation of `runAll`.
    *


### PR DESCRIPTION
This method performs better in some environments for some workloads. It may be worth checking your build to see if it benefits from one method or the other.